### PR TITLE
use Meteor.wrapAsync instead of Meteor._wrapAsync if defined

### DIFF
--- a/redis_driver.js
+++ b/redis_driver.js
@@ -721,7 +721,8 @@ _.each(["insert", "update", "remove", "dropCollection"], function (method) {
 _.each(REDIS_COMMANDS_LOCAL, function (method) {
   RedisConnection.prototype[method] = function (/* arguments */) {
     var self = this;
-    return (Meteor.wrapAsync || Meteor._wrapAsync)(self._client[method]).apply(self._client, arguments);
+    var wrapAsync = Meteor.wrapAsync || Meteor._wrapAsync;
+    return wrapAsync(self._client[method]).apply(self._client, arguments);
   };
 });
 
@@ -734,7 +735,8 @@ _.each(["set", "setex", "append", "del",
 
   RedisConnection.prototype[method] = function (/* arguments */) {
     var self = this;
-    return (Meteor.wrapAsync || Meteor._wrapAsync)(self["_" + method]).apply(self, arguments);
+    var wrapAsync = Meteor.wrapAsync || Meteor._wrapAsync;
+    return wrapAsync(self["_" + method]).apply(self, arguments);
   };
 
   RedisConnection.prototype["_" + method] = function (key /*, arguments */) {


### PR DESCRIPTION
Hello!

Thanks for your work. I am currently using your package in a Meteor 1.0.1 project.

Everytime I set a new entry in Redis DB via this package, the Meteor server logs warns me:

```
Meteor._wrapAsync has been renamed to Meteor.wrapAsync
```

So here is a tiny pull request to use either the new name `wrapAsync` for new Meteor projects, or the former name `_wrapAsync` for older projects.
