### PR TITLE
Remove `mongo-livedata` code where necessary.

### DIFF
--- a/redis_driver.js
+++ b/redis_driver.js
@@ -1073,7 +1073,7 @@ _.extend(SynchronousCursor.prototype, {
 
     self._pos = -1;
 
-    self._visitedIds = new LocalCollection._IdMap;
+    self._visitedIds = new IdMap;
   },
 
   // No-op since we don't actually have a connection to the database.
@@ -1096,7 +1096,7 @@ _.extend(SynchronousCursor.prototype, {
     if (ordered) {
       return self.fetch();
     } else {
-      var results = new LocalCollection._IdMap;
+      var results = new IdMap;
       self.forEach(function (doc) {
         results.set(doc._id, doc);
       });

--- a/redis_driver.js
+++ b/redis_driver.js
@@ -1071,18 +1071,13 @@ _.extend(SynchronousCursor.prototype, {
   rewind: function () {
     var self = this;
 
-    // known to be synchronous
-    self._dbCursor.rewind();
+    self._pos = -1;
 
     self._visitedIds = new LocalCollection._IdMap;
   },
 
-  // Mostly usable for tailable cursors.
-  close: function () {
-    var self = this;
-
-    self._dbCursor.close();
-  },
+  // No-op since we don't actually have a connection to the database.
+  close: function () {},
 
   fetch: function () {
     var self = this;


### PR DESCRIPTION
These references, to non-existent types and variables, cause `redis-livedata` to fail to load under certain conditions.