### PR TITLE
Permit sequences to be skipped.

### DIFF
--- a/oplog_tailing.js
+++ b/oplog_tailing.js
@@ -171,12 +171,17 @@ _.extend(OplogHandle.prototype, {
   _gotSequenceKey: function(message) {
     var self = this;
 
-    if (message != ("sequence_" + (self._sequenceSeen + 1))) {
+    var messageTs = message.split("_")[1];  // Messages are like "sequence_1377".
+
+    // Only balk if we see a sequence that is less than the latest we've seen
+    // --Redis does not guarantee delivery of keyspace notifications but it
+    // should deliver them in order.
+    if (messageTs < (self._sequenceSeen + 1)) {
       Meteor._debug("Got out-of-sequence message: " + message + " vs " + (self._sequenceSeen + 1));
       throw new Error("Sequence received out of sequence");
     }
 
-    self._sequenceSeen++;
+    self._sequenceSeen = messageTs;
 
     var ts = self._sequenceSeen;
     // Now that we've processed this operation, process pending sequencers.


### PR DESCRIPTION
Redis does not guarantee delivery of keyspace notifications, hence we cannot insist
that we observe every sequence key using pubsub alone (without some sort of queuing
and acknowledgment mechanism: http://stackoverflow.com/questions/23675394/redis-publish-subscribe-is-redis-guaranteed-to-deliver-the-message-even-under-m#comment36385109_23681531).

However, notifications will be delivered in order, so I believe it is still semantically correct
to say that we have "caught up"–rather than throwing an error–if we observe a sequence
that is greater than the latest we've seen.
