### PR TITLE
Attempting to fix gracefully #17

### DIFF
--- a/redis_client.js
+++ b/redis_client.js
@@ -82,6 +82,12 @@ RedisClient.prototype.flushall = function (callback) {
   self._connection.flushall(Meteor.bindEnvironment(callback));
 };
 
+RedisClient.prototype.info = function (callback) {
+  var self = this;
+
+  self._connection.info(Meteor.bindEnvironment(callback));
+};
+
 RedisClient.prototype.setex = function (key, expiration, value, callback) {
   var self = this;
   self._connection.setex(key, expiration, value, Meteor.bindEnvironment(callback));

--- a/redis_driver.js
+++ b/redis_driver.js
@@ -265,6 +265,16 @@ RedisConnection = function (url, options) {
 
 // Help the user, by verifying that notify-keyspace-events is set correctly
 function checkConfig(client, fix) {
+
+  // Figure out if we are on Amazon Elasticache, which does not support CONFIG
+  // and other commands: http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ClientConfig.html
+  var notifyInfo = Future.wrap(_.bind(client.info, client))().wait();
+
+  if (notifyInfo.search('os:Amazon ElastiCache')>0) {
+    Meteor._debug("Remember to configure notify-keyspace-events via Amazon GUI/API for ElastiCache");
+    return;
+  }
+
   var notifyConfig = Future.wrap(_.bind(client.getConfig, client))('notify-keyspace-events').wait();
   var config = '';
   var missing = '';


### PR DESCRIPTION
This allows the package to work with Amazon ElastiCache in Redis mode, by bypassing the CONFIG commands calls, which are restricted in Elasticache (see http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ClientConfig.html for more info).

This patch prints a warning to the user, that they need to configure the key notifications within ElastiCache GUI/API as it is the only way to do so.

Let me know if you have any questions.
