### PR TITLE
Added rename_to and rename_from keyspace event handling. 

### DIFF
--- a/keyspace_notification_observe_driver.js
+++ b/keyspace_notification_observe_driver.js
@@ -533,13 +533,13 @@ _.extend(KeyspaceNotificationObserveDriver.prototype, {
     }
 
     var opType = op.message;
-    if (_.contains(['del', 'expired'], opType)) {
+    if (_.contains(['del', 'expired', 'rename_from'], opType)) {
       if (self._published.has(id)) // || (self._limit && self._unpublishedBuffer.has(id)))
         self._removeMatching(id);
     } else if (_.contains(REDIS_COMMANDS_HASH, opType)
         || opType == 'set' || opType == 'append'
         || opType == 'incr' || opType == 'incrby' || opType == 'incrbyfloat'
-        || opType == 'decr' || opType == 'decrby') {
+        || opType == 'decr' || opType == 'decrby' || opType == "rename_to") {
       self._needToFetch.set(id, op); //op.ts.toString());
       if (self._phase === PHASE.STEADY)
         self._fetchModifiedDocuments();


### PR DESCRIPTION
rename_from is identical to deletion and rename_to is identical to addition since we can't relate the two of the published keyspace events.

Signed-off-by: Mehmet Baker mehmetbaker@gmail.com
